### PR TITLE
Remove `_G` global declaration

### DIFF
--- a/dota-std.d.ts
+++ b/dota-std.d.ts
@@ -1,3 +1,2 @@
-declare const _G: any;
 declare function print(this: void, ...messages: any[]): void;
 declare function require(this: void, module: string): any;


### PR DESCRIPTION
Constants can't be defined multiple times, so removing that declaration makes it compatible with https://github.com/TypeScriptToLua/lua-types. Now that tstl supports `globalThis` there shouldn't be much reason to use it anyway.