### PR TITLE
Suggest: Change the parameter context of filterFunc to this

### DIFF
--- a/dota-api.d.ts
+++ b/dota-api.d.ts
@@ -1403,7 +1403,7 @@ declare abstract class CDOTABaseGameMode extends CBaseEntity {
     /**
      * Set a filter function to control the tuning values that abilities use. (Modify the table and Return true to use new values, return false to use the old values)
      */
-    SetAbilityTuningValueFilter<T>(filterFunc: (context: T, event: AbilityTuningEvent) => boolean, context: T): void;
+    SetAbilityTuningValueFilter<T>(filterFunc: (this: T, event: AbilityTuningEvent) => boolean, context: T): void;
     /**
      * Show the player hero's inventory in the HUD, regardless of what unit is selected.
      */
@@ -1435,7 +1435,7 @@ declare abstract class CDOTABaseGameMode extends CBaseEntity {
     /**
      * Set a filter function to control the behavior when a bounty rune is picked up. (Modify the table and Return true to use new values, return false to cancel the event)
      */
-    SetBountyRunePickupFilter<T>(filterFunc: (context: T, event: BountyRunePickupEvent) => boolean, context: T): void;
+    SetBountyRunePickupFilter<T>(filterFunc: (this: T, event: BountyRunePickupEvent) => boolean, context: T): void;
     /**
      * Set a cooldown for the team scan ability
      */
@@ -1498,7 +1498,7 @@ declare abstract class CDOTABaseGameMode extends CBaseEntity {
     /**
      * Set a filter function to control the behavior when a unit takes damage. (Modify the table and Return true to use new values, return false to cancel the event)
      */
-    SetDamageFilter<T>(filterFunc: (context: T, event: DamageEvent) => boolean, context: T): void;
+    SetDamageFilter<T>(filterFunc: (this: T, event: DamageEvent) => boolean, context: T): void;
     /**
      * Enable or disable the day/night cycle.
      */
@@ -1518,7 +1518,7 @@ declare abstract class CDOTABaseGameMode extends CBaseEntity {
     /**
      * Set a filter function to control the behavior when a unit picks up an item. (Modify the table and Return true to use new values, return false to cancel the event)
      */
-    SetExecuteOrderFilter<T>(filterFunc: (context: T, order: ExecuteOrderEvent) => boolean, context: T): void;
+    SetExecuteOrderFilter<T>(filterFunc: (this: T, order: ExecuteOrderEvent) => boolean, context: T): void;
     /**
      * Set a fixed delay for all players to respawn after.
      */
@@ -1558,7 +1558,7 @@ declare abstract class CDOTABaseGameMode extends CBaseEntity {
     /**
      * Set a filter function to control the behavior when a unit heals. (Modify the table and Return true to use new values, return false to cancel the event)
      */
-    SetHealingFilter<T>(filterFunc: (context: T, event: HealingEvent) => boolean, context: T): void;
+    SetHealingFilter<T>(filterFunc: (this: T, event: HealingEvent) => boolean, context: T): void;
     /**
      * Specify whether the default combat events will show in the HUD.
      */
@@ -1566,7 +1566,7 @@ declare abstract class CDOTABaseGameMode extends CBaseEntity {
     /**
      * Set a filter function to control what happens to items that are added to an inventory, return false to cancel the event
      */
-    SetItemAddedToInventoryFilter<T>(filterFunc: (context: T, event: ItemAddedToInventoryEvent) => boolean, context: T): void;
+    SetItemAddedToInventoryFilter<T>(filterFunc: (this: T, event: ItemAddedToInventoryEvent) => boolean, context: T): void;
     /**
      * Unknown
      */
@@ -1590,15 +1590,15 @@ declare abstract class CDOTABaseGameMode extends CBaseEntity {
     /**
      * Set a filter function to control modifiers that are gained, return false to destroy modifier.
      */
-    SetModifierGainedFilter<T>(filterFunc: (context: T, event: ModifierGainedEvent) => boolean, context: T): void;
+    SetModifierGainedFilter<T>(filterFunc: (this: T, event: ModifierGainedEvent) => boolean, context: T): void;
     /**
      * Set a filter function to control the behavior when a hero's experience is modified. (Modify the table and Return true to use new values, return false to cancel the event)
      */
-    SetModifyExperienceFilter<T>(filterFunc: (context: T, event: ModifyExperienceEvent) => boolean, context: T): void;
+    SetModifyExperienceFilter<T>(filterFunc: (this: T, event: ModifyExperienceEvent) => boolean, context: T): void;
     /**
      * Set a filter function to control the behavior when a hero's gold is modified. (Modify the table and Return true to use new values, return false to cancel the event)
      */
-    SetModifyGoldFilter<T>(filterFunc: (context: T, event: ModifyGoldEvent) => boolean, context: T): void;
+    SetModifyGoldFilter<T>(filterFunc: (this: T, event: ModifyGoldEvent) => boolean, context: T): void;
     /**
      * Allow items to be sent to the neutral stash.
      */
@@ -1634,7 +1634,7 @@ declare abstract class CDOTABaseGameMode extends CBaseEntity {
     /**
      * Set a filter function to control what rune spawns. (Modify the table and Return true to use new values, return false to cancel the event)
      */
-    SetRuneSpawnFilter<T>(filterFunc: (context: T, event: RuneSpawnEvent) => boolean, context: T): void;
+    SetRuneSpawnFilter<T>(filterFunc: (this: T, event: RuneSpawnEvent) => boolean, context: T): void;
     /**
      * Enable/disable gold penalty for late picking.
      */
@@ -1670,7 +1670,7 @@ declare abstract class CDOTABaseGameMode extends CBaseEntity {
     /**
      * Set a filter function to control when tracking projectiles are launched. (Modify the table and Return true to use new values, return false to cancel the event)
      */
-    SetTrackingProjectileFilter<T>(filterFunc: (context: T, event: TrackingProjectileEvent) => boolean, context: T): void;
+    SetTrackingProjectileFilter<T>(filterFunc: (this: T, event: TrackingProjectileEvent) => boolean, context: T): void;
     /**
      * Enable or disable unseen fog of war. When enabled parts of the map the player has never seen will be completely hidden by fog of war.
      */


### PR DESCRIPTION
This way it is easy to write the following code.  
The filter must pass context, otherwise it will not work, the context is same as self in Lua.
```js
export default {
    Setup() {
        const GameMode = GameRules.GetGameModeEntity();
        GameMode.SetItemAddedToInventoryFilter(this.OnItemAddedToInventoryFilter, this);
    },

    OnItemAddedToInventoryFilter(event: ItemAddedToInventoryEvent): boolean {
        DeepPrintTable(event);
        return true;
    }
};

// Or
export default {
    Setup() {
        const GameMode = GameRules.GetGameModeEntity();
        GameMode.SetItemAddedToInventoryFilter((event) => {
            return this.OnItemAddedToInventoryFilter(event);
        }, this);
    },

    OnItemAddedToInventoryFilter(event: ItemAddedToInventoryEvent): boolean {
        DeepPrintTable(event);
        return true;
    }
};
```